### PR TITLE
Add support for PostgreSQL GiST operators #17

### DIFF
--- a/lib/lexer.ex
+++ b/lib/lexer.ex
@@ -134,7 +134,7 @@ defmodule SQL.Lexer do
     acc = if type, do: insert_node(node(ident(type, data), line, column, data, opts), acc), else: acc
     lex(rest, binary, opts, line, column, nil, [], insert_node(node(type(b), line, column+1, [], opts), acc), n)
   end
-  def lex(<<b::binary-size(3), rest::binary>>, binary, opts, line, column, type, data, acc, n) when b in ~w[^-= |*= <=>] do
+  def lex(<<b::binary-size(3), rest::binary>>, binary, opts, line, column, type, data, acc, n) when b in ~w[^-= |*= <=> <-> >>= &<| <<| |>> |&> -|-] do
     node = node(String.to_atom(b), line, column+3, [], opts)
     if data == [] do
       lex(rest, binary, opts, line, column+3, type, data, insert_node(node, acc), n)
@@ -142,7 +142,7 @@ defmodule SQL.Lexer do
       lex(rest, binary, opts, line, column+3, nil, [], insert_node(node, insert_node(node(ident(type, data), line, column, data, opts), acc)), n)
     end
   end
-  def lex(<<b::binary-size(2), rest::binary>>, binary, opts, line, column, type, data, acc, n) when b in ~w[:: <> != !< !> <= >= += -= *= /= %= &= ||] do
+  def lex(<<b::binary-size(2), rest::binary>>, binary, opts, line, column, type, data, acc, n) when b in ~w[:: <> != !< !> <= >= += -= *= /= %= &= || << &< && &> >> ~= @> <@ @@] do
     node = node(String.to_atom(b), line, column+2, [], opts)
     if data == [] do
       lex(rest, binary, opts, line, column+2, type, data, insert_node(node, acc), n)

--- a/lib/mix/tasks/sql.gen.parser.ex
+++ b/lib/mix/tasks/sql.gen.parser.ex
@@ -414,7 +414,7 @@ defmodule Mix.Tasks.Sql.Gen.Parser do
       acc = if type, do: insert_node(node(ident(type, data), line, column, data, opts), acc), else: acc
       lex(rest, binary, opts, line, column, nil, [], insert_node(node(type(b), line, column+1, [], opts), acc), n)
     end
-    def lex(<<b::binary-size(3), rest::binary>>, binary, opts, line, column, type, data, acc, n) when b in ~w[^-= |*= <=>] do
+    def lex(<<b::binary-size(3), rest::binary>>, binary, opts, line, column, type, data, acc, n) when b in ~w[^-= |*= <=> <-> >>= &<| <<| |>> |&> -|-] do
       node = node(String.to_atom(b), line, column+3, [], opts)
       if data == [] do
         lex(rest, binary, opts, line, column+3, type, data, insert_node(node, acc), n)
@@ -422,7 +422,7 @@ defmodule Mix.Tasks.Sql.Gen.Parser do
         lex(rest, binary, opts, line, column+3, nil, [], insert_node(node, insert_node(node(ident(type, data), line, column, data, opts), acc)), n)
       end
     end
-    def lex(<<b::binary-size(2), rest::binary>>, binary, opts, line, column, type, data, acc, n) when b in ~w[:: <> != !< !> <= >= += -= *= /= %= &= ||] do
+    def lex(<<b::binary-size(2), rest::binary>>, binary, opts, line, column, type, data, acc, n) when b in ~w[:: <> != !< !> <= >= += -= *= /= %= &= || << &< && &> >> ~= @> <@ @@] do
       node = node(String.to_atom(b), line, column+2, [], opts)
       if data == [] do
         lex(rest, binary, opts, line, column+2, type, data, insert_node(node, acc), n)

--- a/test/adapters/postgres_test.exs
+++ b/test/adapters/postgres_test.exs
@@ -263,6 +263,54 @@ defmodule SQL.Adapters.PostgresTest do
       assert "where id <= 1" == to_string(~SQL[where id <= 1])
       assert "where id <= 1" == to_string(~SQL[where id<=1])
     end
+    test "<<" do
+      assert "where id << 1" == to_string(~SQL[where id << 1])
+    end
+    test "&<" do
+      assert "where id &< 1" == to_string(~SQL[where id &< 1])
+    end
+    test "&&" do
+      assert "where id && 1" == to_string(~SQL[where id && 1])
+    end
+    test "&>" do
+      assert "where id &> 1" == to_string(~SQL[where id &> 1])
+    end
+    test ">>" do
+      assert "where id >> 1" == to_string(~SQL[where id >> 1])
+    end
+    test "~=" do
+      assert "where id ~= 1" == to_string(~SQL[where id ~= 1])
+    end
+    test "@>" do
+      assert "where id @> 1" == to_string(~SQL[where id @> 1])
+    end
+    test "<@" do
+      assert "where id <@ 1" == to_string(~SQL[where id <@ 1])
+    end
+    test "&<|" do
+      assert "where id &<| 1" == to_string(~SQL[where id &<| 1])
+    end
+    test "<<|" do
+      assert "where id <<| 1" == to_string(~SQL[where id <<| 1])
+    end
+    test "|>>" do
+      assert "where id |>> 1" == to_string(~SQL[where id |>> 1])
+    end
+    test "|&>" do
+      assert "where id |&> 1" == to_string(~SQL[where id |&> 1])
+    end
+    test "@@" do
+      assert "where id @@ 1" == to_string(~SQL[where id @@ 1])
+    end
+    test "<->" do
+      assert "where id <-> 1" == to_string(~SQL[where id <-> 1])
+    end
+    test ">>=" do
+      assert "where id <-> 1" == to_string(~SQL[where id <-> 1])
+    end
+    test "-|-" do
+      assert "where id -|- 1" == to_string(~SQL[where id -|- 1])
+    end
     test "between" do
       assert "where id between 1 and 2" == to_string(~SQL[where id between 1 and 2])
       assert "where id not between 1 and 2" == to_string(~SQL[where id not between 1 and 2])


### PR DESCRIPTION
### Summary
This PR adds support for PostgreSQL GiST operators as listed [here](https://www.postgresql.org/docs/current/gist.html#GIST-BUILTIN-OPCLASSES). Partially fixes #17 

### Note
The issue with incorrect parsing of functions (i.e., insertion of a whitespace between the function name and its parentheses) will be addressed in a separate PR.